### PR TITLE
Wollok grammar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
+import fs from "fs";
 
 // https://astro.build/config
 export default defineConfig({
@@ -9,6 +10,15 @@ export default defineConfig({
     starlight({
       title: "Wollok",
       description: "The official Wollok language website.",
+      expressiveCode: {
+        shiki: {
+          langs: [
+            JSON.parse(
+              fs.readFileSync("./src/shiki-grammars/wollok.json", "utf-8")
+            ),
+          ],
+        },
+      },
       favicon: "/favicon.ico",
       logo: {
         light: "./src/assets/branding/imagotipo-pos.svg",

--- a/src/shiki-grammars/wollok.json
+++ b/src/shiki-grammars/wollok.json
@@ -1,0 +1,124 @@
+{
+  "fileTypes": ["wollok"],
+  "name": "wollok",
+  "patterns": [
+    {
+      "include": "#main"
+    }
+  ],
+  "scopeName": "source.wollok",
+  "uuid": "",
+  "repository": {
+    "main": {
+      "patterns": [
+        {
+          "match": "@[A-Za-z]+",
+          "name": "variable.wollok"
+        },
+        {
+          "include": "#numeric"
+        },
+        {
+          "begin": "(\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.operator.wollok"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#main__1"
+            }
+          ],
+          "end": "(\\})",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.operator.wollok"
+            }
+          }
+        },
+        {
+          "match": "(;)",
+          "name": "keyword.operator.wollok"
+        },
+        {
+          "begin": "(\\\"|')",
+          "beginCaptures": {
+            "1": {
+              "name": "string.wollok"
+            }
+          },
+          "contentName": "string.wollok",
+          "end": "(\\\"|')",
+          "endCaptures": {
+            "1": {
+              "name": "string.wollok"
+            }
+          }
+        },
+        {
+          "include": "#multi_line_comment"
+        },
+        {
+          "match": "(//.*)",
+          "name": "comment.wollok"
+        },
+        {
+          "match": "\\b(object|class|package|program|test|describe|method|override|constructor|native|var|const|property|inherits|new|if|else|self|super|import|null|true|false|return|throw|then always|try|catch|mixed with|with|mixin|fixture)\\b",
+          "name": "keyword.wollok"
+        }
+      ]
+    },
+    "main__1": {
+      "patterns": [
+        {
+          "include": "#main"
+        }
+      ]
+    },
+    "main__2": {
+      "patterns": []
+    },
+    "main__3": {
+      "patterns": [
+        {
+          "include": "#numeric"
+        },
+        {
+          "match": "(,)",
+          "name": "keyword.operator.wollok"
+        }
+      ]
+    },
+    "multi_line_comment": {
+      "patterns": [
+        {
+          "begin": "(/\\*)",
+          "beginCaptures": {
+            "1": {
+              "name": "comment.wollok"
+            }
+          },
+          "contentName": "comment.wollok",
+          "end": "(\\*/)",
+          "endCaptures": {
+            "1": {
+              "name": "comment.wollok"
+            }
+          }
+        }
+      ]
+    },
+    "multi_line_comment__1": {
+      "patterns": []
+    },
+    "numeric": {
+      "patterns": [
+        {
+          "match": "(\\b\\d+)",
+          "name": "constant.numeric.wollok"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Tome el archivo https://github.com/uqbar-project/wollok-highlight-vscode/blob/master/syntaxes/wollok.textmate y lo converti a json para cargarlo como gramatica.

Seria ideal poder referenciar al archivo directamente, total despues se puede [parsear](https://www.npmjs.com/package/plist)