### PR TITLE
Fix de la página que se rompió toda todita

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import fs from "fs";
 // https://astro.build/config
 export default defineConfig({
   site: "https://uqbar-project.github.io",
-  base: "/",
+  base: "/website-wollok-ts",
   integrations: [
     starlight({
       title: "Wollok",

--- a/src/content/components/landing-page/LandingIntro.astro
+++ b/src/content/components/landing-page/LandingIntro.astro
@@ -16,14 +16,14 @@ import wollokDiagramLight from '/src/assets/wollok-lsp-diagram-light.png';
       </div>
       <div class="actions">
         <CallToAction
-          link="/getting_started/installation"
+          link="/website-wollok-ts/getting_started/installation"
           variant="primary"
           icon={{ type: "icon", name: "rocket" }}
           attrs={{title: "Instalate Wollok en tu máquina en breves pasos siguiendo este link"}}
         >
           Instalar
         </CallToAction>
-        <CallToAction link="/documentation/language" variant="secondary" attrs={{title: "Si estás buscando cómo implementar un concepto o ayuda sobre los mensajes que podés mandar a un objeto, seguí este link"}}>
+        <CallToAction link="/website-wollok-ts/documentation/language" variant="secondary" attrs={{title: "Si estás buscando cómo implementar un concepto o ayuda sobre los mensajes que podés mandar a un objeto, seguí este link"}}>
           Documentación
         </CallToAction>
         <CallToAction link="https://youtu.be/AwkKZ41U6WE" variant="secondary" attrs={{title: "Acá Fer nos trae una demo Wollok en VSCode usando la versión 0.2.0"}}>

--- a/src/content/docs/getting_started/installation.md
+++ b/src/content/docs/getting_started/installation.md
@@ -158,6 +158,6 @@ Ya deberías poder usar VSCode con Wollok.
 
 ¿Cómo seguimos?
 
-- Podés ver cómo [crear un proyecto Wollok de cero](/getting_started/new_project).
-- Si ya tenés un proyecto Wollok en tu VSCode te recomendamos hacer el [Tour por las herramientas que soportamos](/tour) para sacarle todo el potencial al IDE.
-- Si tenés dudas sobre algo del lenguaje podés [ir a la documentación](/documentation).
+- Podés ver cómo [crear un proyecto Wollok de cero](/website-wollok-ts/getting_started/new_project).
+- Si ya tenés un proyecto Wollok en tu VSCode te recomendamos hacer el [Tour por las herramientas que soportamos](/website-wollok-ts/tour/console) para sacarle todo el potencial al IDE.
+- Si tenés dudas sobre algo del lenguaje podés [ir a la documentación](/website-wollok-ts/documentation/introduction).

--- a/src/content/docs/getting_started/new_project.md
+++ b/src/content/docs/getting_started/new_project.md
@@ -55,5 +55,5 @@ code .
 
 Ahora que ya tenés un proyecto Wollok te invitamos a
 
-- Hacer el [Tour por las herramientas de VSCode](/tour).
-- O sino [ir a la documentación del lenguaje](/documentation).
+- Hacer el [Tour por las herramientas de VSCode](/website-wollok-ts/tour/console).
+- O [ir a la documentación del lenguaje](/website-wollok-ts/documentation/introduction).


### PR DESCRIPTION
![image](https://github.com/uqbar-project/website-wollok-ts/assets/4549002/c0c27791-1cb2-4acd-a454-a7d369cad1cf)

Eso, github pages no redirige bien y rompió también la página de instalación.
