### PR TITLE
Doc search + UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "astro-embed": "^0.7.2",
         "sharp": "^0.32.5",
         "typescript": "^5.3.3",
-        "wollok-ts": "^4.0.7"
+        "wollok-ts": "4.1.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8858,9 +8858,9 @@
       }
     },
     "node_modules/wollok-ts": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.7.tgz",
-      "integrity": "sha512-GT+S0x5MW0Av5r8cvDZTmSiw7OygERYkY6Jnhe738Et23SEKW1dgH8zDqdBnkL5HHYl2X/Z9/33jUL7WyIM1kw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.1.1.tgz",
+      "integrity": "sha512-pALSw4ojwhn2yjOcf6pPr1ujGjUOigD6saSLLl0EWAjcIO3rwhaxqSkpGs/P3CtJk8F8zu8LRtpgNX2K+7mTBQ==",
       "dependencies": {
         "@types/parsimmon": "^1.10.8",
         "parsimmon": "^1.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2658,11 +2658,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -3603,9 +3603,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "astro-embed": "^0.7.2",
     "sharp": "^0.32.5",
     "typescript": "^5.3.3",
-    "wollok-ts": "^4.0.7"
+    "wollok-ts": "4.1.1"
   }
 }

--- a/src/content/components/language/MethodHeading.astro
+++ b/src/content/components/language/MethodHeading.astro
@@ -15,7 +15,9 @@ const { method } = Astro.props;
   {method.isOverride && <Badge variant="note" text="override" />}
   {method.isAbstract() && <Badge variant="caution" text="abstract" />}
   {method.isNative() && <Badge variant="danger" text="native" />}
-  <h5 style="font-family: monospace; margin: 0;" id={identifier(method)}>{methodLabel(method)}</h5>
+  <!-- Hack so it displays Entity.method() on pagefind -->
+  <h5 style="font-family: monospace; margin: 0;" data-pagefind-ignore id={identifier(method)}>{methodLabel(method)}</h5>
+  <h5 style="display: none;" id={identifier(method)}>{method.parent.name}.{methodLabel(method)}</h5>
 </div>
 
 <style>

--- a/src/content/components/language/MethodHeading.astro
+++ b/src/content/components/language/MethodHeading.astro
@@ -1,0 +1,34 @@
+---
+import Badge from "@astrojs/starlight/components/Badge.astro";
+import { Method } from "wollok-ts";
+import { identifier, methodLabel } from "./utils";
+
+interface Props {
+  method: Method;
+}
+
+const { method } = Astro.props;
+---
+
+
+<div id="m-heading-container">
+  {method.isOverride && <Badge variant="note" text="override" />}
+  {method.isAbstract() && <Badge variant="caution" text="abstract" />}
+  {method.isNative() && <Badge variant="danger" text="native" />}
+  <h5 style="font-family: monospace; margin: 0;" id={identifier(method)}>{methodLabel(method)}</h5>
+</div>
+
+<style>
+  #m-heading-container {
+    margin-top: 0.5em;
+    gap: 0.1em;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .sl-badge {
+    white-space: nowrap;
+  }
+</style>
+

--- a/src/content/components/language/MethodHeading.astro
+++ b/src/content/components/language/MethodHeading.astro
@@ -28,9 +28,5 @@ const { method } = Astro.props;
     flex-direction: row;
     align-items: center;
   }
-
-  .sl-badge {
-    white-space: nowrap;
-  }
 </style>
 

--- a/src/content/components/language/WollokDoc.astro
+++ b/src/content/components/language/WollokDoc.astro
@@ -22,6 +22,11 @@ const sanitize = (documentation: string) =>
       (substring) => `<strong>${substring.slice(1)}</strong>`
     )
     .trim();
+const code = examples?.split("\n")
+        .slice(1) // Remove first line
+        .map(sanitize)
+        .filter((_) => _) // Remove empty lines after sanitization
+        .join("\n")
 ---
 
 {
@@ -34,15 +39,18 @@ const sanitize = (documentation: string) =>
   )
 }
 {
-  examples && (
+  code && (
     <Code
-      code={examples
-        .split("\n")
-        .slice(1) // Remove first line
-        .map(sanitize)
-        .filter((_) => _) // Remove empty lines after sanitization
-        .join("\n")}
-      lang="js"
+      code={code}
+      lang='js'
+      theme='github-dark'
+      class='hide-light'
+    />
+    <Code
+      code={code}
+      lang='js'
+      theme='github-light'
+      class='hide-dark'
     />
   )
 }

--- a/src/content/components/language/WollokDoc.astro
+++ b/src/content/components/language/WollokDoc.astro
@@ -2,8 +2,7 @@
 import { Code } from "astro:components";
 import { Node } from "wollok-ts";
 import { wollokDoc } from "./utils";
-import fs from "fs";
-
+import wollokHighlightConfig from "../../../shiki-grammars/wollok.json";
 
 interface Props {
   node: Node;
@@ -49,11 +48,7 @@ const codeThemes = [
   code && (codeThemes.map(({theme, hide}) => (
     <Code
       code={code}
-      lang={            
-        JSON.parse(
-          fs.readFileSync("./src/shiki-grammars/wollok.json", "utf-8")
-        )
-      }
+      lang={wollokHighlightConfig}
       theme={theme}
       class={hide}
     />

--- a/src/content/components/language/WollokDoc.astro
+++ b/src/content/components/language/WollokDoc.astro
@@ -2,6 +2,8 @@
 import { Code } from "astro:components";
 import { Node } from "wollok-ts";
 import { wollokDoc } from "./utils";
+import fs from "fs";
+
 
 interface Props {
   node: Node;
@@ -27,6 +29,11 @@ const code = examples?.split("\n")
         .map(sanitize)
         .filter((_) => _) // Remove empty lines after sanitization
         .join("\n")
+
+const codeThemes = [
+  {theme: 'github-dark', hide: 'hide-light'}, 
+  {theme: 'github-light', hide: 'hide-dark'}
+] as const
 ---
 
 {
@@ -39,18 +46,17 @@ const code = examples?.split("\n")
   )
 }
 {
-  code && (
+  code && (codeThemes.map(({theme, hide}) => (
     <Code
       code={code}
-      lang='js'
-      theme='github-dark'
-      class='hide-light'
+      lang={            
+        JSON.parse(
+          fs.readFileSync("./src/shiki-grammars/wollok.json", "utf-8")
+        )
+      }
+      theme={theme}
+      class={hide}
     />
-    <Code
-      code={code}
-      lang='js'
-      theme='github-light'
-      class='hide-dark'
-    />
+  ))
   )
 }

--- a/src/content/components/language/WollokEntity.astro
+++ b/src/content/components/language/WollokEntity.astro
@@ -15,7 +15,7 @@ const methods = entity.methods.filter((method) => !method.isSynthetic);
 ---
 
 <h3 id={identifier(entity)} class="entity-title">
-  <Badge variant="success" text={entity.kind} />{entity.name}
+  <Badge variant="success" text={entity.kind} /><span>{entity.name}</span>
 </h3>
 
 <WollokDoc node={entity} />
@@ -65,7 +65,9 @@ const methods = entity.methods.filter((method) => !method.isSynthetic);
 
 
 <style>
-  .entity-title {
+
+
+  .entity-title > span{
     text-decoration: underline;
   }
 </style>

--- a/src/content/components/language/WollokEntity.astro
+++ b/src/content/components/language/WollokEntity.astro
@@ -1,7 +1,8 @@
 ---
 import Badge from "@astrojs/starlight/components/Badge.astro";
 import { Class, Mixin, Singleton } from "wollok-ts";
-import { methodLabel } from "./utils";
+import { identifier } from "./utils";
+import MethodHeading from "./MethodHeading.astro";
 import WollokDoc from "./WollokDoc.astro";
 
 interface Props {
@@ -9,9 +10,11 @@ interface Props {
 }
 
 const { entity } = Astro.props;
+
+const methods = entity.methods.filter((method) => !method.isSynthetic);
 ---
 
-<h3 id={entity.fullyQualifiedName}>
+<h3 id={identifier(entity)} class="entity-title">
   <Badge variant="success" text={entity.kind} />{entity.name}
 </h3>
 
@@ -20,7 +23,7 @@ const { entity } = Astro.props;
 {
   entity.fields.length > 0 && (
     <div>
-      <h5>Estado</h5>
+      <h4>Estado</h4>
 
       <table style="width:100%">
         <tr>
@@ -34,38 +37,35 @@ const { entity } = Astro.props;
               {field.isProperty && <Badge variant="caution" text="property" />}
               <strong>{field.name}</strong>
             </td>
-            <td>
+            <td id={identifier(field)}>
               <WollokDoc node={field} />
             </td>
           </tr>
         ))}
       </table>
-
-      <h5>Comportamiento</h5>
     </div>
   )
 }
 
-<table style="width:100%">
-  <tr>
-    <th>Método</th>
-    <th style="width:60%">WollokDoc</th>
-  </tr>
+{
+  methods.length > 0 && 
+  <div>
+    <h4>Comportamiento</h4>
   {
-    entity.methods
-      .filter((method) => !method.isSynthetic)
-      .map((method) => (
-        <tr>
-          <td>
-            {method.isOverride && <Badge variant="note" text="override" />}
-            {method.isAbstract() && <Badge variant="caution" text="abstract" />}
-            {method.isNative() && <Badge variant="danger" text="native" />}
-            <strong>{methodLabel(method)}</strong>
-          </td>
-          <td>
-            <WollokDoc node={method} />
-          </td>
-        </tr>
-      ))
+    methods.map((method) => (
+    <div>
+      <MethodHeading method={method} />
+      <WollokDoc node={method} />
+    </div>
+    ))
   }
-</table>
+  </div>
+}
+
+
+
+<style>
+  .entity-title {
+    text-decoration: underline;
+  }
+</style>

--- a/src/content/components/language/WollokPackage.astro
+++ b/src/content/components/language/WollokPackage.astro
@@ -1,6 +1,7 @@
 ---
 import { Package } from "wollok-ts";
 import WollokEntity from "./WollokEntity.astro";
+import { identifier } from './utils';
 
 interface Props {
   wPackage: Package;
@@ -9,11 +10,26 @@ interface Props {
 const { wPackage } = Astro.props;
 ---
 
-<h2 id={wPackage.fullyQualifiedName}>
-  {wPackage.fileName!.substring("wollok/".length)}
-</h2>
+<div id="p-title-container">
+  <h2 id={identifier(wPackage)}>
+    {wPackage.fileName!.substring("wollok/".length)}
+  </h2>
+</div>
 
 {wPackage.members.map((entity) => <WollokEntity entity={entity as any} />)}
 
 <br />
 <hr />
+
+
+<style>
+  #p-title-container {
+    background-color: var(--sl-color-accent);
+    padding: 2em;
+    border-radius: 10px 10px 50%;
+  }
+
+  #p-title-container > h2 {
+    color: var(--sl-color-text-accent-inverted);
+  }
+</style>

--- a/src/content/components/language/utils.ts
+++ b/src/content/components/language/utils.ts
@@ -35,7 +35,7 @@ export function identifier(node: Package | Entity | Field | Method): string {
     when(Package)(pkg => pkg.fullyQualifiedName),
     when(Entity)(entity => entity.fullyQualifiedName),
     when(Field)(field => `${field.parent.fullyQualifiedName}.${field.name}`),
-    when(Method)(method => `${method.parent.fullyQualifiedName}.${method.name}-${method.parameters.length}`),
+    when(Method)(method => method.label),
   )
 }
 

--- a/src/shiki-grammars/wollok.json
+++ b/src/shiki-grammars/wollok.json
@@ -119,6 +119,8 @@
           "name": "constant.numeric.wollok"
         }
       ]
-    }
+    },
+    "$self": {},
+    "$base": {}
   }
 }

--- a/src/styles/global-styles.css
+++ b/src/styles/global-styles.css
@@ -55,4 +55,5 @@ div.sl-container {
 
 span.sl-badge {
   vertical-align: middle;
+  white-space: nowrap;
 }


### PR DESCRIPTION
fix #23

### Searchbar
- [x] Poder mostrar y navegar hacia los metodos
- [x] En el resultado de la busqueda deberia decir a que entity pertenece el method
<img width="611" alt="image" src="https://github.com/user-attachments/assets/d8baa015-00e8-4d11-99a9-92a0bdbf005e">

### Docu
 - [x] Los metodos ya no se muestra en tabla (nunca logre hacer funcionar [pagefind](pagefind.app), por eso fallaba #23)
 - [x] Si no hay metodos asociados a una entity no mostrar el titulo de "Comportamiento"
 - [x] Bloques de codigo en la docu
   - [x] Themeados dependiendo del estado de la pagina
   - [x] Usan el highlighter de wollok
 - [x] Indicadores visuales para packages/entities/methods
   - Los packages tiene un fondo llamativo
   - Las entities estan subrayadas
   - Los methods estan en fuente monospace


<img width="784" alt="image" src="https://github.com/user-attachments/assets/c5b2b8b2-50ac-4dd9-9aa9-2ece438db7db">
