### PR TITLE
Fix #33 CLI update instructions

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,7 @@
 {
     "MD013": false,
+    "MD029": false,
+    "MD033": false,
     "MD034": false,
     "MD041": false
 }

--- a/src/content/components/landing-page/LandingIntro.astro
+++ b/src/content/components/landing-page/LandingIntro.astro
@@ -16,7 +16,7 @@ import MainRepl from "./repl/MainRepl.astro";
           icon={{ type: "icon", name: "rocket" }}
           attrs={{title: "Instalate Wollok en tu máquina en breves pasos siguiendo este link"}}
         >
-          Instalar
+          Instalar/Actualizar
         </CallToAction>
         <CallToAction link="/documentation/language" variant="secondary" attrs={{title: "Si estás buscando cómo implementar un concepto o ayuda sobre los mensajes que podés mandar a un objeto, seguí este link"}}>
           Documentación

--- a/src/content/docs/getting_started/installation.md
+++ b/src/content/docs/getting_started/installation.md
@@ -1,5 +1,5 @@
 ---
-title: Instalación
+title: Instalación/Actualización
 description: Pasos para instalar Wollok
 sidebar:
     order: 1
@@ -8,28 +8,33 @@ sidebar:
 ## Componentes básicos
 
 Tenemos estos tres componentes para instalar:
+
 - Wollok-CLI (el intérprete del lenguaje)
 - IDE (Visual Studio Code)
 - Extensiones (desarrolladas para VSCode)
 
+### Wollok CLI
 
-### Wollok CLI 
 El intérprete del lenguaje es Wollok-CLI (Command Line Interface)
-Es el ejecutable que corre los programas Wollok. 
+Es el ejecutable que corre los programas Wollok.
 Hay dos formas de instalarlo:
+
 - [Via Node](/getting_started/installation_recomended) (recomendada en computadoras de uso personal)
+
 :::note[Recomendada]
 Es la forma recomendada de instalar Wollok, por ser la variante más simple, por tener una forma de actualización ágil y por tener optimizaciones que mejoran su performance. Si llegás a tener inconvenientes, podés probar la otra alternativa.
 :::
-- [Descargando ejecutable](/getting_started/installation_alternative) (alternativa para computadoras de uso compartido) 
+
+- [Descargando ejecutable](/getting_started/installation_alternative) (alternativa para computadoras de uso compartido)
+
 :::caution[Alternativa]
-Se aconseja si surgen conflictos con otras instalaciones de Node, si surgen dificultades con la instalación recomendada, o si es para un uso eventual) 
+Se aconseja si surgen conflictos con otras instalaciones de Node, si surgen dificultades con la instalación recomendada, o si es para un uso eventual)
 :::
 En ambos casos, tener en cuenta las particularidades del sistema operativo.
 
 ### IDE
 
-El Entorno Integrado de Desarrollo (IDE) recomenado es Visual Studio Code (VSCode), por contar con las extensiones que hacen más grata la experiencia de aprender a programar con Wollok. 
+El Entorno Integrado de Desarrollo (IDE) recomenado es Visual Studio Code (VSCode), por contar con las extensiones que hacen más grata la experiencia de aprender a programar con Wollok.
 De todas maneras, el código fuente es simplemente texto y se puede editar con cualquier editor.
 
 Instalar [VSCode](https://code.visualstudio.com/).
@@ -56,7 +61,6 @@ Podés ir a la tab de Extensiones, buscar 'wollok' e instalarlas como muestra es
 
 <img width="449" alt="image" src="https://user-images.githubusercontent.com/4098184/204097656-18de3a1e-88c5-4315-8f1b-14480b59a50f.png"/>
 
-
 4. Ahora es necesario **configurar la extensión** para que pueda usar _Wollok-CLI_ para correr programas.
 
 - Ir a la pestaña de "ajustes" (o "settings" en inglés) del VSCode: `Ctrl + ,` o desde el menú: `Code -> Preferencias -> Ajustes`. Y buscar por `wollok`.
@@ -73,13 +77,14 @@ Podés ir a la tab de Extensiones, buscar 'wollok' e instalarlas como muestra es
 
 Ya deberías poder usar VSCode con Wollok.
 
-
 ## Videos explicativos
 
-**Windows** 
+### **Windows**
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/kPxbjL7WUHc?si=lmdkD9oF2SxMpFeg" title="YouTube video player" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-**Linux**
+### **Linux**
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/DCG-syufqhU?si=SBMGmBkEz6bS1-Wo" title="YouTube video player" frameborder="0" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Próximos pasos

--- a/src/content/docs/getting_started/installation_alternative.md
+++ b/src/content/docs/getting_started/installation_alternative.md
@@ -5,28 +5,30 @@ description: Pasos para instalar Wollok descargando ejecutable
 
 ## Wollok Command Line Interface: vía ejecutable
 
-Es un serie de pasos que se debe realizar inicialmente y repetirla  cada vez que haya una nueva versión disponible. 
+Es un serie de pasos que se debe realizar inicialmente y repetirla  cada vez que haya una nueva versión disponible.
+
 - Descargar un archivo ejecutable
 - Renombrarlo
 - Ubicarlo en una carpeta donde se tenga acceso
 - Garantizar que tenga permiso de ejecución.
 
 La forma de realizarlos depende de cada Sistema Operativo
-A continuación te dejamos las instrucciones para cada caso.
 
-### Windows
+:::note[Descarga]
+A continuación te dejamos las instrucciones para cada caso, para lo cual el primer paso es descargar la _Wollok Command Line Interface_ (Wollok-CLI) disponible para tu sistema operativo: [Windows](https://github.com/uqbar-project/wollok-ts-cli/releases/latest/download/wollok-ts-cli-win-x64.exe), [Linux](https://github.com/uqbar-project/wollok-ts-cli/releases/latest/download/wollok-ts-cli-linux-x64) o [Mac](https://github.com/uqbar-project/wollok-ts-cli/releases/latest/download/wollok-ts-cli-macos-x64).
+:::
 
-1. Descargar la _Wollok Command Line Interface_ (Wollok-CLI) disponible para [Windows](https://github.com/uqbar-project/wollok-ts-cli/releases/latest/download/wollok-ts-cli-win-x64.exe).
+### Instalación en Windows
 
 Teniendo en cuenta que nos descargamos la versión de Wollok CLI de Windows en la carpeta `Downloads` del usuario logueado  y que el usuario se llama `NombreDeUsuario`, haremos lo siguiente
 
-2. Crear una carpeta `Wollok` dentro del home del usuario (en este caso: `C:\Users\NombreDeUsuario`)
-3. Mover el archivo de la carpeta `C:\Users\NombreDeUsuario\Downloads` a `C:\Users\NombreDeUsuario\Wollok`. Es importante dejarlo dentro de las carpetas del usuario logueado para no tener problemas de permisos.
-4. Renombrar el ejecutable a `wollok.exe`.
+1. Crear una carpeta `Wollok` dentro del home del usuario (en este caso: `C:\Users\NombreDeUsuario`)
+2. Mover el archivo de la carpeta `C:\Users\NombreDeUsuario\Downloads` a `C:\Users\NombreDeUsuario\Wollok`. Es importante dejarlo dentro de las carpetas del usuario logueado para no tener problemas de permisos.
+3. Renombrar el ejecutable a `wollok.exe`.
 
 ![wollok-ts-cli-path-win-2](https://github.com/uqbar-project/website-wollok-ts/assets/4549002/e1a917d9-8bb4-4457-8592-3a44b751468d)
 
-5. Por último vamos a agregar la carpeta Wollok que acabamos de crear a la lista de carpetas que forman parte del PATH. Para eso abrimos la configuración de variables de entorno:
+4. Por último vamos a agregar la carpeta Wollok que acabamos de crear a la lista de carpetas que forman parte del PATH. Para eso abrimos la configuración de variables de entorno:
 
 - activamos la ventana de ejecución de comandos con las teclas `Windows` y `R`
 - escribimos `sysdm.cpl` que es el programa que levanta el `Panel de Control`
@@ -40,7 +42,7 @@ Teniendo en cuenta que nos descargamos la versión de Wollok CLI de Windows en l
 
 ![Variables de entorno avanzadas](../../../assets/wollok-ts-cli-path-win-env.gif)
 
-6. Para comprobar que Wollok-CLI se instaló correctamente nos posicionamos en una carpeta diferente a `C:/Users/NombreDeUsuario/Wollok` y ejecutamos `wollok --version` en cualquier terminal (podés usar Powershell, CMD o Git Bash, el resultado es el mismo):
+5. Para comprobar que Wollok-CLI se instaló correctamente nos posicionamos en una carpeta diferente a `C:/Users/NombreDeUsuario/Wollok` y ejecutamos `wollok --version` en cualquier terminal (podés usar Powershell, CMD o Git Bash, el resultado es el mismo):
 
 ![Verificación wollok ts cli](../../../assets/wollok-ts-cli-path-win-3.gif)
 
@@ -48,12 +50,12 @@ Teniendo en cuenta que nos descargamos la versión de Wollok CLI de Windows en l
 La versión que muestre será la última que te hayas descargado (no tiene que ser 0.2.2)
 :::
 
-### Linux
+### Instalación en Linux
 
 1. Primero vamos a necesitar levantar una terminal con `Ctrl + Alt + T` o buscando `Terminal` en la barra de herramientas
 
-2. Asumimos que descargamos la versión del cli en la carpeta `~/Downloads` (`~` es la carpeta raíz del usuario logueado), vamos a renombrar el archivo a `wollok`, darle permisos de ejecución (`chmod a+x`), pasarlo a la carpeta `/usr/local/bin` y confirmar con `ls -la` que el archivo está en esa carpeta y que tiene las tres `x` correspondientes a los permisos de ejecución. Lo hacemos con una serie de comandos como la siguiente: 
-   
+2. Asumimos que descargamos la versión del cli en la carpeta `~/Downloads` (`~` es la carpeta raíz del usuario logueado), vamos a renombrar el archivo a `wollok`, darle permisos de ejecución (`chmod a+x`), pasarlo a la carpeta `/usr/local/bin` y confirmar con `ls -la` que el archivo está en esa carpeta y que tiene las tres `x` correspondientes a los permisos de ejecución. Lo hacemos con una serie de comandos como la siguiente:
+
 ```bash
 cd ~/Downloads
 ls -la wollok-ts-cli*
@@ -75,7 +77,7 @@ Te mostramos cómo se hace esta parte desde una terminal:
 La versión que muestre será la última que te hayas descargado (no tiene que ser 0.2.2)
 :::
 
-### Mac
+### Instalación en Mac
 
 1. Vamos a necesitar levantar una terminal con `⌘ (Cmd) + Espacio` o buscando `Terminal` en el Launchpad
 
@@ -94,7 +96,6 @@ Te mostramos cómo hacerlo desde una terminal de Mac:
 
 ![Rename & give access to wollok ts cli executable in Mac](../../../assets/wollok-ts-cli-mac-cmd-2.gif)
 
-
 3. Para verificar que esté correctamente instalado necesitamos algunos pasos más gracias al mecanismo de seguridad que trae el sistema operativo Mac:
 
 - debemos ejecutar `wollok --version` la primera vez
@@ -110,3 +111,30 @@ Te mostramos cómo hacerlo desde una terminal de Mac:
 La versión que muestre será la última que te hayas descargado (no tiene que ser 0.2.2)
 :::
 
+### Actualización (en cualquier sistema operativo)
+
+Si ya instalaste el CLI de Wollok y querés actualizarlo, primero verificá qué versión tenés instalada. En la terminal escribí:
+
+```bash
+wollok --version
+```
+
+Descargá el ejecutable disponible para tu sistema operativo: [Windows](https://github.com/uqbar-project/wollok-ts-cli/releases/latest/download/wollok-ts-cli-win-x64.exe), [Linux](https://github.com/uqbar-project/wollok-ts-cli/releases/latest/download/wollok-ts-cli-linux-x64) o [Mac](https://github.com/uqbar-project/wollok-ts-cli/releases/latest/download/wollok-ts-cli-macos-x64). Reemplazá el nuevo ejecutable por el anterior en la misma carpeta donde lo instalaste, si no recordás dónde lo ubicaste podés utilizar
+
+```bash
+# en Linux/Mac
+which wollok
+```
+
+o
+
+```bat
+:: en Windows
+where wollok
+```
+
+Luego verificá si tenés un nuevo número de versión:
+
+```bash
+wollok --version
+```

--- a/src/content/docs/getting_started/installation_recomended.md
+++ b/src/content/docs/getting_started/installation_recomended.md
@@ -7,8 +7,7 @@ sidebar:
 
 ## Wollok Command Line Interface: vía Node
 
-
-### Windows
+### Instalación en Windows
 
 Instalar la versión 20 de Node desde [el link oficial](https://nodejs.org/en) haciendo click en la opción "Download Node.js (LTS)". Luego ejecutás el instalador y seleccionás Next dejando todas las opciones por defecto. En caso de dudas te recomendamos que veas [este tutorial](https://www.youtube.com/watch?v=29mihvA_zEA71)
 
@@ -48,7 +47,7 @@ wollok --version
 La versión que muestre será la última que te hayas descargado (no tiene que ser 0.2.2)
 :::
 
-### Linux
+### Instalación en Linux
 
 Instalar la versión 20 de Node desde [este link](https://nodejs.org/en/download/package-manager). La opción más simple es que uses **nvm** (Node Version Manager), un ejecutable que te permite manejar diferentes versiones de Node en tu máquina local. Seleccioná la última versión que aparezca para Node 20, el sistema operativo Linux y la variante nvm.
 
@@ -76,7 +75,7 @@ npm i -g wollok-ts-cli
 
 Verificamos que tenemos instalado Wollok CLI. En la terminal escribimos:
 
-```zsh
+```bash
 wollok --version
 ```
 
@@ -86,7 +85,7 @@ wollok --version
 La versión que muestre será la última que te hayas descargado (no tiene que ser 0.2.2)
 :::
 
-### Mac
+### Instalación en Mac
 
 Instalar la versión 20 de Node desde [este link](https://nodejs.org/en/download/package-manager). La opción más simple es que uses **brew** o **nvm** (Node Version Manager), un ejecutable que te permite manejar diferentes versiones de Node en tu máquina local. Seleccioná la última versión que aparezca para Node 20, el sistema operativo Linux y la variante nvm o brew.
 
@@ -121,3 +120,23 @@ wollok --version
 :::note[Sobre la versión]
 La versión que muestre será la última que te hayas descargado (no tiene que ser 0.2.2)
 :::
+
+### Actualización (en cualquier sistema operativo)
+
+Si ya instalaste el CLI de Wollok y querés actualizarlo, primero verificá qué versión tenés instalada. En la terminal escribí:
+
+```bash
+wollok --version
+```
+
+En una consola ejecutá el siguiente comando:
+
+```bash
+npm i -g wollok-ts-cli
+```
+
+Luego verificá si tenés un nuevo número de versión:
+
+```bash
+wollok --version
+```

--- a/src/content/docs/material/lectures.md
+++ b/src/content/docs/material/lectures.md
@@ -9,39 +9,32 @@ A continuación presentamos una serie de capítulos que integran los principales
 
 - <a href="https://docs.google.com/document/d/1RBfNmKZFKZ90XvfQsN7zhtuUPV2Mvj7t-iyZiL2bClQ/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">01</span>&nbsp;&nbsp;&nbsp;Objetos. Mensajes. Métodos.</a>
 
-- <a href="https://docs.google.com/document/d/14092iRsXDXih8-q_0UEXIGRSQmGtxL9pay1VXX4ceJg/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">02</span>&nbsp;&nbsp;&nbsp; Referencias. Estado. Compartir objetos. Identidad.</a>
+- <a href="https://docs.google.com/document/d/14092iRsXDXih8-q_0UEXIGRSQmGtxL9pay1VXX4ceJg/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">02</span> - Referencias. Estado. Compartir objetos. Identidad.</a>
 
-- <a href="https://docs.google.com/document/d/1X7Sz12e7rbVO1x7uMD7ECjZnT-chELx0ElTPmNvNURU/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">03</span>&nbsp;&nbsp;&nbsp; Introducción a Polimorfismo. </a>
+- <a href="https://docs.google.com/document/d/1X7Sz12e7rbVO1x7uMD7ECjZnT-chELx0ElTPmNvNURU/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">03</span> - Introducción a Polimorfismo. </a>
 
-- <a href="https://docs.google.com/document/d/1HiYxLswd4O0MBqnT3jGo2K9e_4FE73RXF_lf8NWVOSE/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">04</span>&nbsp;&nbsp;&nbsp; Objetos básicos. Números. Strings. Fechas. Bloques. Conjuntos. Listas. </a>
+- <a href="https://docs.google.com/document/d/1HiYxLswd4O0MBqnT3jGo2K9e_4FE73RXF_lf8NWVOSE/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">04</span> - Objetos básicos. Números. Strings. Fechas. Bloques. Conjuntos. Listas. </a>
 
-- <a href="https://docs.google.com/document/d/1Q_v48gZfRmVfLMvC0PBpmtZyMoALbh11AwmEllP__eY/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">05</span>&nbsp;&nbsp;&nbsp; Introducción al testeo unitario automatizado. </a>
+- <a href="https://docs.google.com/document/d/1Q_v48gZfRmVfLMvC0PBpmtZyMoALbh11AwmEllP__eY/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">05</span> - Introducción al testeo unitario automatizado. </a>
 
-- <a href="https://docs.google.com/document/d/1j2VoBNczPsMXrIjJ4tycYU982CZahReTvzkWS9TTKV0/edit?usp=sharing?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">06</span>&nbsp;&nbsp;&nbsp; Objetos anónimos y repaso polimorfismo. </a>
+- <a href="https://docs.google.com/document/d/1j2VoBNczPsMXrIjJ4tycYU982CZahReTvzkWS9TTKV0/edit?usp=sharing?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">06</span> - Objetos anónimos y repaso polimorfismo. </a>
 
-- <a href="https://docs.google.com/document/d/1wziW1YY-t94UUAUApydrt-OZ5roq1uY6DT6FduwNGx0/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">07</span>&nbsp;&nbsp;&nbsp; Propiedades. </a>
+- <a href="https://docs.google.com/document/d/1wziW1YY-t94UUAUApydrt-OZ5roq1uY6DT6FduwNGx0/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">07</span> - Propiedades. </a>
 
-- <a href="https://docs.google.com/document/d/1Dgq_PfCbJHO1M7dXe-vGXtj4mbEUWlYhfvQ2i0RWOsk/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">08</span>&nbsp;&nbsp;&nbsp; Clases. Method lookup y polimorfismo con clases.</a>
+- <a href="https://docs.google.com/document/d/1Dgq_PfCbJHO1M7dXe-vGXtj4mbEUWlYhfvQ2i0RWOsk/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">08</span> - Clases. Method lookup y polimorfismo con clases.</a>
 
-- <a href="https://docs.google.com/document/d/11c9l3sqgUIFDx1J_ULCSS86faMQXAyOV3uesg-nwaSY/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">09</span>&nbsp;&nbsp;&nbsp; Herramientas de instanciación.</a>
+- <a href="https://docs.google.com/document/d/11c9l3sqgUIFDx1J_ULCSS86faMQXAyOV3uesg-nwaSY/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">09</span> - Herramientas de instanciación.</a>
 
-- <a href="https://docs.google.com/document/d/1T87tmdXv_39RoE_zR7alVFK8TUl-KJYOhdoIsoVTRb4/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">10</span>&nbsp;&nbsp;&nbsp; Manejo de errores.</a>
+- <a href="https://docs.google.com/document/d/1T87tmdXv_39RoE_zR7alVFK8TUl-KJYOhdoIsoVTRb4/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">10</span> - Manejo de errores.</a>
 
-- <a href="https://docs.google.com/document/d/1caDE_mlP1QMfzyVpyvh-tKshjAeYLXBkXDYrTX5zFUI/edit#?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">11</span>&nbsp;&nbsp;&nbsp; Testeo unitario automatizado avanzado.</a>        
+- <a href="https://docs.google.com/document/d/1caDE_mlP1QMfzyVpyvh-tKshjAeYLXBkXDYrTX5zFUI/edit#?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">11</span> - Testeo unitario automatizado avanzado.</a>
 
-- <a href="https://docs.google.com/document/d/1MLbx1Fxt7I_uVg6Yv9hYfIu2IIbUQqqICbOM3s969D8/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">12</span>&nbsp;&nbsp;&nbsp; Colecciones. Bloques de código.</a>
+- <a href="https://docs.google.com/document/d/1MLbx1Fxt7I_uVg6Yv9hYfIu2IIbUQqqICbOM3s969D8/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">12</span> - Colecciones. Bloques de código.</a>
 
-- <a href="https://docs.google.com/document/d/1KdG7NrKPgPh4bAcyLuDG2G1iWP7Ze2GFs91qzlvDKqI/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">13</span>&nbsp;&nbsp;&nbsp; Herencia. Self, super. Redefinición.</a>
+- <a href="https://docs.google.com/document/d/1KdG7NrKPgPh4bAcyLuDG2G1iWP7Ze2GFs91qzlvDKqI/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">13</span> - Herencia. Self, super. Redefinición.</a>
 
-- <a href="https://docs.google.com/document/d/18QtQCs91tXX1e4kpEPs4sLU-TRJsxcoEKVngMDf278c/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">14</span>&nbsp;&nbsp;&nbsp; Mutabilidad. Igualdad e identidad. </a>
+- <a href="https://docs.google.com/document/d/18QtQCs91tXX1e4kpEPs4sLU-TRJsxcoEKVngMDf278c/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">14</span> - Mutabilidad. Igualdad e identidad. </a>
 
-- <a href="https://docs.google.com/document/d/1lRTDAcsOwy7hkAM-UvTZtMHzN5fitrWyk1JAM-6NVJI/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">15</span>&nbsp;&nbsp;&nbsp; Elementos de Diseño.</a>
+- <a href="https://docs.google.com/document/d/1lRTDAcsOwy7hkAM-UvTZtMHzN5fitrWyk1JAM-6NVJI/edit?usp=drive_web" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">15</span> - Elementos de Diseño.</a>
 
-- <a href="https://docs.google.com/document/d/1VPKwf_cHcFTCj9JSYZ-xJmchX_n10bSJwxTUcmpd3w0/edit?usp=sharing" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">16</span>&nbsp;&nbsp;&nbsp; Herencia vs. composición. El proceso de Diseño.</a>        
-
-- <a href="https://docs.google.com/document/d/1A6JB4EretksCyMDvOj4NzfiEzX8yfboDTZnER7x_xJI/edit" target="_blank"><span class="badge blue-grey lighten-1 badge-pill">Anexo 1</span>&nbsp;&nbsp;&nbsp; Guía de shortcuts del entorno Wollok.</a>
-
-- <a href="https://docs.google.com/document/d/1p4W1wwzzdvzfdGbvXexbE3arwyAAg1xirYW68Twkatc/edit#" target="_blank"><span class="badge blue-grey lighten-1 badge-pill">Anexo 2</span>&nbsp;&nbsp;&nbsp; Tutorial de Git en Wollok.</a> O si preferís, tenés el <a href="https://docs.google.com/document/d/1uisxrnkFdC2uBexBChSKpxYohjd90-tejALOSAVZodo/edit?usp=sharing" target="_blank"> Tutorial de SVN en Wollok.</a>
-
-- <a href="https://docs.google.com/document/d/1K3A5kSZHZH7QmPHAQ-Hwt_t_5OKweeeaqF670DLS9Y0/edit?usp=sharing" target="_blank"><span class="badge blue-grey lighten-1 badge-pill">Anexo 3</span>&nbsp;&nbsp;&nbsp; Diagrama estático de Wollok.</a>
-
+- <a href="https://docs.google.com/document/d/1VPKwf_cHcFTCj9JSYZ-xJmchX_n10bSJwxTUcmpd3w0/edit?usp=sharing" target="_blank"><span class="badge mdb-color lighten-1 badge-pill">16</span> - Herencia vs. composición. El proceso de Diseño.</a>


### PR DESCRIPTION
Se agregaron instrucciones para actualizar el CLI desde npm o ejecutables:

![image](https://github.com/user-attachments/assets/7b11c31a-cd9d-4f20-b17d-767ed0e0b97d)

![cli-update](https://github.com/user-attachments/assets/20119753-7690-4d21-a933-eb41492e0c5d)

De paso, se fixeó los warnings de markdown que tenían las páginas modificadas. Y también se soluciona #52 .