### PR TITLE
Arreglo links

### DIFF
--- a/src/content/components/Footer.astro
+++ b/src/content/components/Footer.astro
@@ -12,7 +12,7 @@ const t = translations.default;
 ---
 
 <footer>
-  Copyright © 2025, <a href="http://www.uqbar.org/">Fundación Uqbar</a>, {isEnglish ? "All rights reserved. Distributed under" : "Todos los derechos reservados. Distribuido según licencia"}
+  Copyright © 2026, <a href="http://www.uqbar.org/">Fundación Uqbar</a>, {isEnglish ? "All rights reserved. Distributed under" : "Todos los derechos reservados. Distribuido según licencia"}
   <a href="https://www.gnu.org/licenses/lgpl-3.0.txt"
     >LGPLv3</a
   > {isEnglish ? "license" : ""}

--- a/src/content/components/landing-page/LandingCommunity.astro
+++ b/src/content/components/landing-page/LandingCommunity.astro
@@ -60,13 +60,6 @@ const t = translations.default;
   margin-top: 0 !important;
 }
 
-a {
-  color: var(--sl-color-accent) !important;
-}
-
-a:hover {
-  color: var(--sl-color-accent-hover) !important;
-}
 
 @media(max-width: 50em) {
   .community-container {

--- a/src/content/components/landing-page/what-is-wollok/card-2.md
+++ b/src/content/components/landing-page/what-is-wollok/card-2.md
@@ -2,6 +2,6 @@ Es un proyecto _open source_ desarrollado por <a href="https://uqbar.org" target
 
 <style>
   .sl-markdown-content a {
-    color: #00E5FF;  /*var(--sl-color-text-accent-inverted)*/
+    color: #00E5FF;
   }
 </style>

--- a/src/content/components/landing-page/what-is-wollok/card-2.md
+++ b/src/content/components/landing-page/what-is-wollok/card-2.md
@@ -2,6 +2,6 @@ Es un proyecto _open source_ desarrollado por <a href="https://uqbar.org" target
 
 <style>
   .sl-markdown-content a {
-    color: var(--sl-color-text-accent-inverted);
+    color: #00E5FF;  /*var(--sl-color-text-accent-inverted)*/
   }
 </style>

--- a/src/content/components/landing-page/what-is-wollok/en/card-2.md
+++ b/src/content/components/landing-page/what-is-wollok/en/card-2.md
@@ -2,6 +2,6 @@ It is an _open source_ project developed by <a href="https://uqbar.org" target="
 
 <style>
   .sl-markdown-content a {
-    color: var(--sl-color-text-accent-inverted);
+     color: #00E5FF;  /*var(--sl-color-text-accent-inverted)*/
   }
 </style>

--- a/src/content/components/landing-page/what-is-wollok/en/card-2.md
+++ b/src/content/components/landing-page/what-is-wollok/en/card-2.md
@@ -2,6 +2,6 @@ It is an _open source_ project developed by <a href="https://uqbar.org" target="
 
 <style>
   .sl-markdown-content a {
-     color: #00E5FF;  /*var(--sl-color-text-accent-inverted)*/
+    color: #00E5FF;
   }
 </style>


### PR DESCRIPTION
fix #76 

El problema explicado:

Lo que ocurre es que la sección: what is wollok que contiene 4 cards rojas en medio de la pagina
Tiene un link (a) que al poner el modo claro se vuelve el link (a) blanco porque lo rodea rojo, ósea que en blanco se ve a todos los links de la sección comunidad. 
 
Y uno de los afectados son los tres links en la parte baja de la página: que se vuelven blanco también. Pero ellos no están rodeados de rojo u otro color para poder verse. 

Y eso mismo pasa en Modo Oscuro
Solo que el todo el texto de las cards y el link (a) se vuelve oscuro. y los links de la sección comunidad tambien.

Ocurriendo el mismo problema, pero por diferente color del modo Oscuro/claro.

El estilo que afecta a ambos es: .sl-markdown-content a
Es el que está dentro del archivo: en/card-2.md y es/card-2.md    
 
<img width="844" height="214" alt="problem-S-S-md" src="https://github.com/user-attachments/assets/351d17c5-7ef8-4ecd-8812-192aa56dbe04" />


_______________________________________________________________________________________________________________________________________

Posible Solución:

solución fácil y simple:

cambiar el color de: en/card-2.md y es/card-2.md    
 
a un color más visible tanto en modo oscuro y claro, 
ósea que, aunque este rodeado de rojo oscuro o de blanco o de negro.

como seria el amarillo dorado, el celeste o el verde.


Modo Claro:
 
<img width="848" height="243" alt="S-S-im" src="https://github.com/user-attachments/assets/c9daf229-8397-4405-ac3d-ea8fde62c0c9" />


<img width="1335" height="433" alt="S-S-ims" src="https://github.com/user-attachments/assets/ad251e37-8bcf-4c23-8941-84a9073220da" />

 --------------------------------------------------------------------------------------------------------------------------------------------

Modo oscuro:
 

<img width="797" height="287" alt="S-S-img1" src="https://github.com/user-attachments/assets/dd194910-6714-47b2-81b9-3f027a4a1b51" />

 
<img width="1320" height="417" alt="S-S-img2" src="https://github.com/user-attachments/assets/de29eff2-1417-43ec-b994-229f5c68bdd5" />


------------------------------------------------------------------------------------------------------------------------------------------


Se realizo la modificacion del footer, actualizar a el año actual:

<img width="672" height="70" alt="footer issue 76" src="https://github.com/user-attachments/assets/4ed17224-954a-4cac-98ba-e856ec671e29" />

