### PR TITLE
corregir la Pagina: ¿Quienes usan Wollok?

### DIFF
--- a/src/content/docs/news/Quiénes usan Wollok.md
+++ b/src/content/docs/news/Quiénes usan Wollok.md
@@ -2,10 +2,6 @@
 title: ¿Quienes usan wollok?
 description: universidades
   
----
-
-#### Universidades que utilizan wollok:
-#### Para enseñar sobre POO (Programacion Orientada a Objetos)
 
 ---
 
@@ -29,7 +25,7 @@ description: universidades
     <h4 class="nombre_uni">Universidad Nacional de Quilmes (UNQ)</h4> 
    </a>
 
-   <p class="materia">Materia:  <b>Programación con Objetos 1</b> - <a href="https://sites.google.com/view/unq-cpi-obj1-c1/home">asignatura</p>
+   <p class="materia">Materia:  <b>Programación con Objetos 1</b> - <a href="https://www.unq.edu.ar/carrera/58-licenciatura-en-informatica/">carrera</p>
 
    <img src="https://thfvnext.bing.com/th/id/OIP.gYZmvyRN3qo6LJwtLIfYOAAAAA?w=213&h=90&c=7&r=0&o=7&cb=thfvnextfalcon&pid=1.7&rm=3" alt="imagen UNQ"> 
 
@@ -67,6 +63,7 @@ description: universidades
 <style>
 
    .universidad{
+      text-align: center;
       margin-top: 40px;
       margin-bottom: 40px;
       font-size: 19px;
@@ -86,7 +83,10 @@ description: universidades
    }
    
    .universidad img{
-      width: 100%;
+      /*text-align: center;*/
+      display: block;
+      margin: auto;
+      width: 50%;
       max-width: 656px;
       height: auto;
    }


### PR DESCRIPTION
fix #73 

se corrigió estos problemas: 
---
* UNQ: mencionar la carrera (donde está la materia: programación con objetos 1) - en vez de la asignatura. 
 porque no existe un sitio web oficial de la asignatura
---
* eliminar el sub_titulo
---
* centrar todo y achicar las imágenes de la correspondiente universidad
---

<img width="2468" height="3400" alt="localhost_4321_news_qui%C3%A9nes-usan-wollok_ (1)" src="https://github.com/user-attachments/assets/0a06d481-3b42-49c4-8e71-e19fa35f44ac" />

-----------------------------------------------------------------------------------------------------------------------------------------

<img width="1283" height="226" alt="cambio4" src="https://github.com/user-attachments/assets/52397390-3308-484d-8734-dea79e9f9f16" />
<img width="1220" height="204" alt="cambio3" src="https://github.com/user-attachments/assets/06b22dad-966e-4875-ba21-db041585134e" />
<img width="1298" height="315" alt="cambio2" src="https://github.com/user-attachments/assets/042b07e9-f044-43ec-bdf1-8c02ee96d081" />
<img width="1114" height="236" alt="cambio1" src="https://github.com/user-attachments/assets/404f6434-5c4a-4898-a2c3-ae7a6a5239d8" />
