### PR TITLE
coreccion: nombre_uni

### DIFF
--- a/src/content/docs/news/Quiénes usan Wollok.md
+++ b/src/content/docs/news/Quiénes usan Wollok.md
@@ -79,7 +79,7 @@ description: universidades
    }
 
    .nombre_uni{
-      color: white;
+      color: var(--sl-color-accent);
    }
    
    .universidad img{


### PR DESCRIPTION
#fix_issue 73

corrección en la página: ¿Quienes usan Wollok?

los títulos de cada universidad: están en blanco:
- no se ven cuando ponemos el modo claro letra blanca en fondo blanco no se ve
- en modo oscuro si se ve

<img width="2468" height="3400" alt="www wollok org_news_qui%C3%A9nes-usan-wollok_ (1)" src="https://github.com/user-attachments/assets/57d46d47-21ab-4912-aa5b-e9e3b088d9dc" />
<img width="2468" height="3400" alt="localhost_4321_news_qui%C3%A9nes-usan-wollok_ (2)" src="https://github.com/user-attachments/assets/76e93c72-b739-427e-8e0e-77867815e968" />

---

Asi que use una variable-estilo global de la Pagina Web ya existente:

<img width="2468" height="3400" alt="localhost_4321_news_qui%C3%A9nes-usan-wollok_ (3)" src="https://github.com/user-attachments/assets/08e4b1c4-5e02-4534-a05a-6c038205858c" />


